### PR TITLE
fix: heading for npm readme

### DIFF
--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -31,7 +31,7 @@
     - **`vue.runtime.esm-bundler.js` (default)** is runtime only, and requires all templates to be pre-compiled. This is the default entry for bundlers (via `module` field in `package.json`) because when using a bundler templates are typically pre-compiled (e.g. in `*.vue` files).
     - **`vue.esm-bundler.js`**: includes the runtime compiler. Use this if you are using a bundler but still want runtime template compilation (e.g. in-DOM templates or templates via inline JavaScript strings). You will need to configure your bundler to alias `vue` to this file.
 
-  #### Bundler Build Feature Flags
+#### Bundler Build Feature Flags
 
   Starting with 3.0.0-rc.3, `esm-bundler` builds now exposes global feature flags that can be overwritten at compile time:
 


### PR DESCRIPTION
H4 not showing correctly for https://www.npmjs.com/package/vue/v/3.0.0